### PR TITLE
expose EdgewareTypes via index.ts

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,15 @@
+import { IdentityTypes } from './identity';
+import { SignalingTypes } from './signaling';
+import { TreasuryRewardTypes } from './treasuryReward';
+import { VotingTypes } from './voting';
+
+export const EdgewareTypes = {
+  PreVoting: VotingTypes.PreVoting,
+  Voting: VotingTypes.Voting,
+  Completed: VotingTypes.Completed,
+  Commit: VotingTypes.Commit,
+  VoteStage,
+  ProposalRecord,
+  ProposalContents: Bytes,
+  ProposalTitle: Bytes,
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,12 +4,8 @@ import { TreasuryRewardTypes } from './treasuryReward';
 import { VotingTypes } from './voting';
 
 export const EdgewareTypes = {
-  PreVoting: VotingTypes.PreVoting,
-  Voting: VotingTypes.Voting,
-  Completed: VotingTypes.Completed,
-  Commit: VotingTypes.Commit,
-  VoteStage,
-  ProposalRecord,
-  ProposalContents: Bytes,
-  ProposalTitle: Bytes,
+  ...IdentityTypes,
+  ...SignalingTypes,
+  ...TreasuryRewardTypes,
+  ...VotingTypes
 };


### PR DESCRIPTION
This allows users to shortcut the process a tiny bit, i.e. on the polkadot-js side doing this at least in two places (and probably don't need to know much about the internal modules are diff. parts) -

- extension (new) - https://github.com/polkadot-js/extension/pull/153/files#diff-238e61a7406f819b33ad6ccdfc104c99R7
- apps UI (existing) - https://github.com/polkadot-js/apps/blob/master/packages/react-api/src/overrides/spec/edgeware.ts#L5

This would allow to shortcut this and just do an `import { EdgewareTypes } from '@edgeware-node-types/dist';`