### PR TITLE
Import & use AccountId as interface

### DIFF
--- a/types/identity.ts
+++ b/types/identity.ts
@@ -1,7 +1,7 @@
 import { Bytes, Text, u32, Null } from '@polkadot/types';
 import { Option, Struct, Enum } from '@polkadot/types/codec';
+import { AccountId } from '@polkadot/types/interfaces';
 import { Registry } from '@polkadot/types/types';
-import AccountId from '@polkadot/types/primitive/Generic/AccountId';
 
 export class MetadataRecord extends Struct {
   constructor (registry: Registry, value: any) {
@@ -39,7 +39,7 @@ export class IdentityStage extends Enum {
 export class IdentityRecord extends Struct {
   constructor (registry: Registry, value: any) {
     super(registry, {
-      account: AccountId,
+      account: 'AccountId',
       identity_type: Text,
       identity: Bytes,
       stage: IdentityStage,

--- a/types/signaling.ts
+++ b/types/signaling.ts
@@ -1,14 +1,14 @@
 import { u32, Text, u64, Bytes } from '@polkadot/types';
 import { Struct } from '@polkadot/types/codec';
+import { AccountId } from '@polkadot/types/interfaces';
 import { Registry } from '@polkadot/types/types';
 import { VotingTypes, VoteStage } from './voting';
-import AccountId from '@polkadot/types/primitive/Generic/AccountId';
 
 export class ProposalRecord extends Struct {
   constructor (registry: Registry, value: any) {
     super(registry, {
       index: u32,
-      author: AccountId,
+      author: 'AccountId',
       stage: VoteStage,
       transition_time: u32,
       title: Text,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -1,7 +1,7 @@
 import { Null, bool, u64, Enum, Struct, Vec, Tuple, Option, u128 } from '@polkadot/types';
 import U8aFixed from '@polkadot/types/codec/U8aFixed';
+import { AccountId } from '@polkadot/types/interfaces';
 import { AnyU8a, Registry } from '@polkadot/types/types';
-import AccountId from '@polkadot/types/primitive/Generic/AccountId';
 
 export class PreVoting extends Null { }
 export class Commit extends Null { }
@@ -56,7 +56,7 @@ export class Tally extends Option.with(Vec.with(Tuple.with([VoteOutcome, u128]))
 export class VoteData extends Struct {
   constructor (registry: Registry, value: any) {
     super(registry, {
-      initiator: AccountId,
+      initiator: 'AccountId',
       stage: VoteStage,
       vote_type: VoteType,
       tally_type: TallyType,
@@ -80,8 +80,8 @@ export class VoteData extends Struct {
   }
 }
 
-export class Commitments extends Vec.with(Tuple.with([AccountId, VoteOutcome])) { }
-export class Reveals extends Vec.with(Tuple.with([AccountId, Vec.with(VoteOutcome)])) { }
+export class Commitments extends Vec.with(Tuple.with(['AccountId', VoteOutcome])) { }
+export class Reveals extends Vec.with(Tuple.with(['AccountId', Vec.with(VoteOutcome)])) { }
 
 export class VoteRecord extends Struct {
   constructor (registry: Registry, value: any) {


### PR DESCRIPTION
This removes the need to keep the structure in-sync with the API, e.g. in 1.4 the internal folder structures are changing. (Specifically around the generic types)