### PR TITLE
fix: adjust node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "README.md"
   ],
   "engines": {
-    "node": "^14.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Currently the syntax for the specified node engine is `^14.0.0`, but it needs to be `>=14.0.0`. The latter will allow for versions above 14 to be used while running `@polkadot/apps-config`.

The current syntax will not allow a successful download of `@polkadot/apps-config` from the npm registry or any package that utilizes it if the local node version is above 14. 

rel: [#601](https://github.com/paritytech/substrate-api-sidecar/issues/601)

